### PR TITLE
Update appinfo.json

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -42,7 +42,7 @@
     },
     "shortName": "FTC Timer",
     "uuid": "14898afa-0329-49f2-ab26-8abb74e53c40",
-    "versionCode": 010,
+    "versionCode": "010",
     "versionLabel": "0.1",
     "watchapp": {
         "watchface": false


### PR DESCRIPTION
I had to make this change to avoid the following build error on OSX 10.10.1 with `pebble-sdk` installed with `brew`:

```
 » pebble build               
Setting top to                           : /Users/j/Source/pebble-ftc-timer 
Setting out to                           : /Users/j/Source/pebble-ftc-timer/build 
Checking for program gcc,cc              : arm-none-eabi-gcc 
Checking for program ar                  : arm-none-eabi-ar 
Found Pebble SDK in          : /usr/local/Cellar/pebble-sdk/2.8.1/Pebble
'configure' finished successfully (0.072s)
Waf: Entering directory `/Users/j/Source/pebble-ftc-timer/build'
Traceback (most recent call last):
  File "/usr/local/Cellar/pebble-sdk/2.8.1/Pebble/.waf-1.7.11-04343383b3a9511074383c51ae32d355/waflib/Scripting.py", line 97, in waf_entry_point
    run_commands()
  File "/usr/local/Cellar/pebble-sdk/2.8.1/Pebble/.waf-1.7.11-04343383b3a9511074383c51ae32d355/waflib/Scripting.py", line 153, in run_commands
    ctx=run_command(cmd_name)
  File "/usr/local/Cellar/pebble-sdk/2.8.1/Pebble/.waf-1.7.11-04343383b3a9511074383c51ae32d355/waflib/Scripting.py", line 146, in run_command
    ctx.execute()
  File "/usr/local/Cellar/pebble-sdk/2.8.1/Pebble/.waf-1.7.11-04343383b3a9511074383c51ae32d355/waflib/Scripting.py", line 351, in execute
    return execute_method(self)
  File "/usr/local/Cellar/pebble-sdk/2.8.1/Pebble/.waf-1.7.11-04343383b3a9511074383c51ae32d355/waflib/Build.py", line 106, in execute
    self.execute_build()
  File "/usr/local/Cellar/pebble-sdk/2.8.1/Pebble/.waf-1.7.11-04343383b3a9511074383c51ae32d355/waflib/Build.py", line 109, in execute_build
    self.recurse([self.run_dir])
  File "/usr/local/Cellar/pebble-sdk/2.8.1/Pebble/.waf-1.7.11-04343383b3a9511074383c51ae32d355/waflib/Context.py", line 128, in recurse
    user_function(self)
  File "/Users/j/Source/pebble-ftc-timer/wscript", line 43, in build
    ctx.load('pebble_sdk')
  File "/usr/local/Cellar/pebble-sdk/2.8.1/Pebble/.waf-1.7.11-04343383b3a9511074383c51ae32d355/waflib/Context.py", line 84, in load
    fun(self)
  File "/usr/local/Cellar/pebble-sdk/2.8.1/Pebble/.waf-1.7.11-04343383b3a9511074383c51ae32d355/waflib/extras/pebble_sdk.py", line 70, in build
    _generate_resources(bld,appinfo_json_node,sdk_folder)
  File "/usr/local/Cellar/pebble-sdk/2.8.1/Pebble/.waf-1.7.11-04343383b3a9511074383c51ae32d355/waflib/extras/pebble_sdk.py", line 66, in _generate_resources
    appinfo=json.load(f)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 290, in load
    **kw)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py", line 365, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py", line 381, in raw_decode
    obj, end = self.scan_once(s, idx)
ValueError: Expecting , delimiter: line 45 column 21 (char 1165)
[ERROR   ] A compilation error occurred
```
