### PR TITLE
Minor bug fixes

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -42,7 +42,7 @@
     },
     "shortName": "FTC Timer",
     "uuid": "14898afa-0329-49f2-ab26-8abb74e53c40",
-    "versionCode": "010",
+    "versionCode": 010,
     "versionLabel": "0.1",
     "watchapp": {
         "watchface": false

--- a/appinfo.json
+++ b/appinfo.json
@@ -3,29 +3,14 @@
     "capabilities": [
         ""
     ],
-    "companyName": "i\u00b2robotics",
+    "companyName": "i²robotics",
     "longName": "FTC Match Timer",
     "projectType": "native",
     "resources": {
         "media": [
             {
-                "file": "images/pause.png",
-                "name": "IMAGE_PAUSE",
-                "type": "png"
-            },
-            {
-                "file": "images/settings.png",
-                "name": "IMAGE_SETTINGS",
-                "type": "png"
-            },
-            {
-                "file": "images/play.png",
-                "name": "IMAGE_PLAY",
-                "type": "png"
-            },
-            {
-                "file": "images/home.png",
-                "name": "IMAGE_HOME",
+                "file": "images/stop.png",
+                "name": "IMAGE_STOP",
                 "type": "png"
             },
             {
@@ -34,15 +19,30 @@
                 "type": "png"
             },
             {
-                "file": "images/stop.png",
-                "name": "IMAGE_STOP",
+                "file": "images/home.png",
+                "name": "IMAGE_HOME",
+                "type": "png"
+            },
+            {
+                "file": "images/play.png",
+                "name": "IMAGE_PLAY",
+                "type": "png"
+            },
+            {
+                "file": "images/settings.png",
+                "name": "IMAGE_SETTINGS",
+                "type": "png"
+            },
+            {
+                "file": "images/pause.png",
+                "name": "IMAGE_PAUSE",
                 "type": "png"
             }
         ]
     },
     "shortName": "FTC Timer",
     "uuid": "14898afa-0329-49f2-ab26-8abb74e53c40",
-    "versionCode": 10,
+    "versionCode": "010",
     "versionLabel": "0.1",
     "watchapp": {
         "watchface": false

--- a/appinfo.json
+++ b/appinfo.json
@@ -42,7 +42,7 @@
     },
     "shortName": "FTC Timer",
     "uuid": "14898afa-0329-49f2-ab26-8abb74e53c40",
-    "versionCode": 010,
+    "versionCode": "010",
     "versionLabel": "0.1",
     "watchapp": {
         "watchface": false

--- a/appinfo.json
+++ b/appinfo.json
@@ -3,29 +3,14 @@
     "capabilities": [
         ""
     ],
-    "companyName": "i²robotics",
+    "companyName": "i\u00b2robotics",
     "longName": "FTC Match Timer",
     "projectType": "native",
     "resources": {
         "media": [
             {
-                "file": "images/stop.png",
-                "name": "IMAGE_STOP",
-                "type": "png"
-            },
-            {
-                "file": "images/tele.png",
-                "name": "IMAGE_TELE",
-                "type": "png"
-            },
-            {
-                "file": "images/home.png",
-                "name": "IMAGE_HOME",
-                "type": "png"
-            },
-            {
-                "file": "images/play.png",
-                "name": "IMAGE_PLAY",
+                "file": "images/pause.png",
+                "name": "IMAGE_PAUSE",
                 "type": "png"
             },
             {
@@ -34,15 +19,30 @@
                 "type": "png"
             },
             {
-                "file": "images/pause.png",
-                "name": "IMAGE_PAUSE",
+                "file": "images/play.png",
+                "name": "IMAGE_PLAY",
+                "type": "png"
+            },
+            {
+                "file": "images/home.png",
+                "name": "IMAGE_HOME",
+                "type": "png"
+            },
+            {
+                "file": "images/tele.png",
+                "name": "IMAGE_TELE",
+                "type": "png"
+            },
+            {
+                "file": "images/stop.png",
+                "name": "IMAGE_STOP",
                 "type": "png"
             }
         ]
     },
     "shortName": "FTC Timer",
     "uuid": "14898afa-0329-49f2-ab26-8abb74e53c40",
-    "versionCode": "010",
+    "versionCode": 10,
     "versionLabel": "0.1",
     "watchapp": {
         "watchface": false

--- a/src/button_click.c
+++ b/src/button_click.c
@@ -50,7 +50,8 @@ void tick_handler(struct tm *tick_time, TimeUnits units_changed)
   char *time_str = "2:00";
 
   //strftime(time_str, 5, "%M:%S", (const struct *tm){.tm_min = AD_time_value/60, .tm_sec = AD_time_value%60});
-  snprintf(time_str, 5, "%i:%i", AD_time_value / 60, AD_time_value % 60);
+  //Prepend "0" to seconds if less than 10 seconds remain in minute
+  snprintf(time_str, 5, (AD_time_value%60 < 10) ? "%i:0%i" : "%i:%i", AD_time_value / 60, AD_time_value % 60);
   text_layer_set_text(time_layer, time_str);
 
   if (STATE_INACTIVE) {

--- a/src/button_click.c
+++ b/src/button_click.c
@@ -24,15 +24,15 @@ enum
   kStateAuto,
   kStateTeleOp
 } ADTimerState;
-int AD_time_value = 0;
+static int AD_end_time = 0;
 const int AD_warning_time = 30;
 bool AD_do_auto = true;
 
-//========== Tick Handler ==========
-void tick_handler(struct tm *tick_time, TimeUnits units_changed)
-{
-  //APP_LOG(APP_LOG_LEVEL_DEBUG, "tick: %i", AD_time_value);
-  AD_time_value--;
+void update_timer(){
+  int AD_time_value = AD_end_time - time(NULL);
+  APP_LOG(APP_LOG_LEVEL_DEBUG, "tick: %i", AD_time_value);
+
+  
   if (AD_time_value == 0) {
     vibes_long_pulse();
     light_enable_interaction();
@@ -60,23 +60,30 @@ void tick_handler(struct tm *tick_time, TimeUnits units_changed)
   }
 }
 
+//========== Tick Handler ==========
+void tick_handler(struct tm *tick_time, TimeUnits units_changed)
+{
+  update_timer();
+}
+
 //========== Primary Actions ==========
 void AD_start_timer()
 {
   if (ADTimerState == kStateWaiting || AD_do_auto == false) {
-    AD_time_value = 120;
+    AD_end_time = time(NULL) + 120;
     ADTimerState = kStateTeleOp;
     text_layer_set_text(text_layer, "TeleOp");
     text_layer_set_text(time_layer, "2:00");
     tick_timer_service_subscribe(SECOND_UNIT, (TickHandler) tick_handler);
   } else if (ADTimerState == kStateOff) {
-    AD_time_value = 30;
+    AD_end_time = time(NULL) + 30;
     ADTimerState = kStateAuto;
     text_layer_set_text(text_layer, "Autonomous");
     text_layer_set_text(time_layer, "0:30");
     tick_timer_service_subscribe(SECOND_UNIT, (TickHandler) tick_handler);
   }
   action_bar_layer_set_icon(action_bar, BUTTON_ID_DOWN, (ADTimerState == kStateOff || ADTimerState == kStateWaiting) ? action_icon_play : action_icon_stop);
+  update_timer();
 }
 
 void AD_end_timer()


### PR DESCRIPTION
Thanks for making an app for Pebble and FTC! In the course of using it, I noticed a couple minor bugs.
- When the number of seconds remaining in the minutes was less than 10, the timer would display 1:5 instead of the proper 1:05
- Immediately after restarting or resuming  the timer, the time displayed would show the old value for a fraction of a second.

In the course of fixing this, I extracted the tick_handler() code to a new update_timer() function and switched to using time-difference instead of decrementing the seconds.
